### PR TITLE
Implemented hypermedia decoupling of robot

### DIFF
--- a/tapas-executor-1/pom.xml
+++ b/tapas-executor-1/pom.xml
@@ -16,6 +16,12 @@
 	<properties>
 		<java.version>11</java.version>
 	</properties>
+	<repositories>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+	</repositories>
 	<dependencies>
 
 		<dependency>
@@ -50,7 +56,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>com.github.Interactions-HSG</groupId>
+			<artifactId>wot-td-java</artifactId>
+			<version>v0.1.1</version>
+		</dependency>
 	</dependencies>
 
 

--- a/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/adapters/out/QuerySearchEngineHttpAdapter.java
+++ b/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/adapters/out/QuerySearchEngineHttpAdapter.java
@@ -1,0 +1,72 @@
+package ch.unisg.tapasexecutor.adapters.out;
+
+import ch.unisg.tapasexecutor.application.ports.out.QuerySearchEnginePort;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+@Component
+@Log4j2
+public class QuerySearchEngineHttpAdapter implements QuerySearchEnginePort {
+
+
+    @Value("${sparql.search.engine.uri}")
+    private String sparqlSearchEngineUri;
+
+    private final String SPARQL_QUERY = "@prefix td: <https://www.w3.org/2019/wot/td#>.\n" +
+            "select ?x\n" +
+            "where { ?x a td:Thing }";
+    private final String KEYWORD = "leubot";
+
+    private HttpClient client = HttpClient.newHttpClient();
+
+    @Override
+    public Optional<String> querySearchEngine() {
+        log.info("Sending query for " + KEYWORD + " to search engine at " + sparqlSearchEngineUri);
+        Optional<String> robotUri = Optional.empty();
+        HttpRequest sparqlRequest = HttpRequest.newBuilder()
+                .uri(URI.create(sparqlSearchEngineUri))
+                .headers("Content-Type", "application/sparql-query")
+                .POST(HttpRequest.BodyPublishers.ofString(SPARQL_QUERY))
+                .build();
+        try {
+            HttpResponse sparqlResponse = client.send(sparqlRequest, HttpResponse.BodyHandlers.ofString());
+            // Read values from XML-response and search for Leubot URI
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            StringBuilder xmlStringBuilder = new StringBuilder();
+
+            String xmlString = sparqlResponse.body().toString().replace("\n", "");
+            xmlStringBuilder.append(xmlString);
+            ByteArrayInputStream input = new ByteArrayInputStream(
+                    xmlStringBuilder.toString().getBytes(StandardCharsets.UTF_8));
+            Document doc = builder.parse(input);
+            doc.getDocumentElement().normalize();
+            NodeList resultElements = doc.getElementsByTagName("result");
+            for (int i = 0; i < resultElements.getLength(); i++) {
+                String retrievedUri = resultElements.item(i).getFirstChild().getFirstChild().getTextContent();
+                if (retrievedUri.contains(KEYWORD)) {
+                    robotUri = Optional.of(retrievedUri);
+                    log.info("Search engine returned the following Leubot URI: "+ retrievedUri);
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            log.error("Querying search engine failed");
+            e.printStackTrace();
+        }
+        return robotUri;
+    }
+}

--- a/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/adapters/out/RobotHttpAdapter.java
+++ b/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/adapters/out/RobotHttpAdapter.java
@@ -3,7 +3,6 @@ package ch.unisg.tapasexecutor.adapters.out;
 import ch.unisg.tapasexecutor.adapters.out.robot.RobotApi;
 import ch.unisg.tapasexecutor.application.ports.out.RobotPort;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -13,8 +12,6 @@ import java.time.Instant;
 @Component
 public class RobotHttpAdapter implements RobotPort {
 
-    @Value("${ch.tapas.executor-1.robot-api-url}")
-    private String robotApiUrl;
 
     /**
      * Receives and input string (from the task object) executes the task
@@ -24,11 +21,11 @@ public class RobotHttpAdapter implements RobotPort {
      * @return
      */
     @Override
-    public String executeTask(String inputValue) {
+    public String executeTask(String inputValue, String robotTDUri) {
 
         var start = Instant.now();
 
-        try (var api = RobotApi.open(robotApiUrl)) {
+        try (var api = RobotApi.open(robotTDUri)) {
 
             api.dance();
 

--- a/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/adapters/out/robot/RobotApi.java
+++ b/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/adapters/out/robot/RobotApi.java
@@ -1,5 +1,17 @@
 package ch.unisg.tapasexecutor.adapters.out.robot;
 
+import ch.unisg.ics.interactions.wot.td.ThingDescription;
+import ch.unisg.ics.interactions.wot.td.affordances.ActionAffordance;
+import ch.unisg.ics.interactions.wot.td.affordances.Form;
+import ch.unisg.ics.interactions.wot.td.clients.TDHttpRequest;
+import ch.unisg.ics.interactions.wot.td.clients.TDHttpResponse;
+import ch.unisg.ics.interactions.wot.td.io.TDGraphReader;
+import ch.unisg.ics.interactions.wot.td.schemas.DataSchema;
+import ch.unisg.ics.interactions.wot.td.schemas.ObjectSchema;
+import ch.unisg.ics.interactions.wot.td.security.APIKeySecurityScheme;
+import ch.unisg.ics.interactions.wot.td.security.SecurityScheme;
+import ch.unisg.ics.interactions.wot.td.vocabularies.TD;
+import ch.unisg.ics.interactions.wot.td.vocabularies.WoTSec;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.log4j.Log4j2;
 
@@ -13,11 +25,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @Log4j2
 public class RobotApi implements Closeable {
 
     private static final long rateLimitingMillis = 1100;
+    private ThingDescription td;
     private final String robotUri;
     private final HttpClient client = HttpClient.newHttpClient();
     private String apiKey;
@@ -25,13 +39,14 @@ public class RobotApi implements Closeable {
     private final ObjectMapper om = new ObjectMapper();
     private Instant lastAPICall = Instant.ofEpochSecond(0);
 
-    public RobotApi(String robotUri) {
-        this.robotUri = robotUri;
+    public RobotApi(String robotTDUri) throws Exception {
+        this.td = TDGraphReader.readFromURL(ThingDescription.TDFormat.RDF_TURTLE, robotTDUri);
+        this.robotUri = td.getBaseURI().get();
     }
 
-    public static RobotApi open(String robotUrl) throws Exception {
+    public static RobotApi open(String robotTDUri) throws Exception {
 
-        var api = new RobotApi(robotUrl);
+        var api = new RobotApi(robotTDUri);
         api.createUser();
         return api;
     }
@@ -42,12 +57,60 @@ public class RobotApi implements Closeable {
         body.put("name", "TAPAS Group 3");
         body.put("email", "weDontHaveAEmailButYouCanOpenAIssueONGitHub@tapas.SCS-ASSE-FS21-Group3.github.com");
 
-        var response = makeRequest("POST", "/user", body);
+        // TODO: This request cannot be decoupled, because there is no option to retrieve headers from TDHttpResponse
+        // https://github.com/Interactions-HSG/wot-td-java/issues/67
+        var response = makeRequest("POST", "user", body);
 
         var location = response.headers().firstValue("Location");
         this.apiKeyDeleteEndpoint = location.get();
         var idx = apiKeyDeleteEndpoint.lastIndexOf("/");
         this.apiKey = apiKeyDeleteEndpoint.substring(idx + 1);
+    }
+
+    private TDHttpResponse makeRequestDecoupled(String actionName, Map<String, Object> payload) throws Exception {
+
+        Optional<ActionAffordance> actionAffordance = td.getActionByName(actionName);
+        if (actionAffordance.isEmpty())
+            throw new RuntimeException("Action \"" + actionName + "\" not found in things description");
+
+        Optional<Form> form = actionAffordance.get().getFirstFormForOperationType(TD.invokeAction);
+        if (form.isEmpty())
+            throw new RuntimeException("Form for action \"" + actionName + "\" not found in things description");
+
+        TDHttpRequest request = new TDHttpRequest(form.get(), TD.invokeAction);
+
+        // Check if the action requires a payload
+        Optional<DataSchema> inputSchema = actionAffordance.get().getInputSchema();
+        if (inputSchema.isPresent()) {
+            request.setObjectPayload((ObjectSchema) inputSchema.get(), payload);
+        }
+        // Add api key if we have one
+        if (apiKey != null) {
+            Optional<SecurityScheme> securityScheme = td.getFirstSecuritySchemeByType(WoTSec.APIKeySecurityScheme);
+            if (securityScheme.isPresent()) {
+                request.setAPIKey((APIKeySecurityScheme) securityScheme.get(), apiKey);
+            }
+        }
+
+        // Wait for rate limiting
+        var timeSinceLastCall = Duration.between(lastAPICall, Instant.now()).toMillis();
+
+        if (timeSinceLastCall < rateLimitingMillis)
+            Thread.sleep(rateLimitingMillis - timeSinceLastCall);
+
+
+        TDHttpResponse response = request.execute();
+        lastAPICall = Instant.now();
+
+        // Log response
+        int statusCode = response.getStatusCode();
+        log.info("TD HTTP Request action \"" + actionName + "\" resulted in status code " + statusCode);
+
+        // Check if ok
+        if (statusCode >= 300 || statusCode < 200)
+            throw new RuntimeException("Unexpected status code: " + statusCode);
+
+        return response;
     }
 
     private HttpResponse<String> makeRequest(String method, String endpoint, Map<String, Object> body) throws Exception {
@@ -95,19 +158,19 @@ public class RobotApi implements Closeable {
 
     public void dance() throws Exception {
 
-        moveRobot("/elbow", 400);
-        moveRobot("/elbow", 650);
-        moveRobot("/elbow", 400);
-        moveRobot("/elbow", 650);
-        moveRobot("/reset", 0);
+        moveRobot("setElbow", 400);
+        moveRobot("setElbow", 650);
+        moveRobot("setElbow", 400);
+        moveRobot("setElbow", 650);
+        moveRobot("reset", 0);
     }
 
-    private HttpResponse<String> moveRobot(String endpoint, int value) throws Exception {
+    private void moveRobot(String actionName, int value) throws Exception {
 
         var body = new HashMap<String, Object>();
         body.put("value", value);
 
-        return makeRequest("PUT", endpoint, body);
+        makeRequestDecoupled(actionName,body);
     }
 
     @Override
@@ -115,6 +178,7 @@ public class RobotApi implements Closeable {
 
         try {
             if (this.apiKeyDeleteEndpoint != null)
+                // This request cannot be decoupled, because there is no option to retrieve headers from TDHttpResponse
                 makeRequest("DELETE", this.apiKeyDeleteEndpoint, null);
         } catch (Exception exception) {
             throw new IOException(exception);

--- a/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/application/ports/out/QuerySearchEnginePort.java
+++ b/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/application/ports/out/QuerySearchEnginePort.java
@@ -1,0 +1,7 @@
+package ch.unisg.tapasexecutor.application.ports.out;
+
+import java.util.Optional;
+
+public interface QuerySearchEnginePort {
+    Optional<String> querySearchEngine();
+}

--- a/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/application/ports/out/RobotPort.java
+++ b/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/application/ports/out/RobotPort.java
@@ -2,5 +2,5 @@ package ch.unisg.tapasexecutor.application.ports.out;
 
 public interface RobotPort {
 
-    String executeTask(String inputValue);
+    String executeTask(String inputValue, String robotTDUri);
 }

--- a/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/application/service/RobotService.java
+++ b/tapas-executor-1/src/main/java/ch/unisg/tapasexecutor/application/service/RobotService.java
@@ -2,6 +2,7 @@ package ch.unisg.tapasexecutor.application.service;
 
 import ch.unisg.tapasexecutor.application.ports.in.ExecuteRobotTaskUseCase;
 import ch.unisg.tapasexecutor.application.ports.in.IsTaskAcceptableQuery;
+import ch.unisg.tapasexecutor.application.ports.out.QuerySearchEnginePort;
 import ch.unisg.tapasexecutor.application.ports.out.RobotPort;
 import ch.unisg.tapasexecutor.application.ports.out.UpdateTaskPort;
 import ch.unisg.tapasexecutor.domain.Task;
@@ -9,6 +10,8 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Log4j2
 @Component
@@ -20,6 +23,9 @@ public class RobotService implements IsTaskAcceptableQuery, ExecuteRobotTaskUseC
     @Autowired
     private RobotPort robotPort;
 
+    @Autowired
+    private QuerySearchEnginePort querySearchEnginePort;
+
     @Override
     @Async("threadPoolTaskExecutor")
     public void executeRobotTask(Task task) {
@@ -27,7 +33,14 @@ public class RobotService implements IsTaskAcceptableQuery, ExecuteRobotTaskUseC
         if (!isAcceptable(task))
             throw new IllegalArgumentException("Task is not acceptable");
 
-        var outputData = robotPort.executeTask(task.getInputData().getValue());
+        // TODO: Temporarily hardcoded because the search engine server is extremely unstable
+        String robotTDUri = "http://yggdrasil.interactions.ics.unisg.ch/environments/61/workspaces/102/artifacts/leubot1";
+        //Optional<String> robotTDUriOptional = querySearchEnginePort.querySearchEngine();
+        //if (robotTDUriOptional.isEmpty())
+        //    throw new RuntimeException("No TD uri could be returned from search engine");
+        //String robotTDUri = robotTDUriOptional.get();
+
+        var outputData = robotPort.executeTask(task.getInputData().getValue(), robotTDUri);
         task.setOutputData(new Task.OutputData(outputData));
 
         updateTaskPort.setTaskComplete(task);

--- a/tapas-executor-1/src/main/resources/application.properties
+++ b/tapas-executor-1/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 server.port=8091
 spring.application.name=Executor 1
-
-ch.tapas.executor-1.robot-api-url=https://api.interactions.ics.unisg.ch/leubot1/v1.3.4
+sparql.search.engine.uri = https://api.interactions.ics.unisg.ch/search/searchEngine
 ch.tapas.executor-1.executor-pool-url=http://tapas-executor-pool:8083


### PR DESCRIPTION
Hello @gianlucafrei 
This PR essentially "decouples" the robot executor. "Decouples" because the search engine server is so unstable that I needed to comment out this functionality and hardcode the Things Description URI of the Leubot in our code.
Also, there is no possibility to issue a request to delete a user from the leubot API using the tutors [wot-td-library](https://github.com/Interactions-HSG/wot-td-java) and also no possibility to retrieve the API key from the header (See [this issue](https://github.com/Interactions-HSG/wot-td-java/issues/67)). 
Essentially we now perform the log in and deletion of the user with a standard HTTP request and the rest of the commands by using the retrieved things description.